### PR TITLE
Removes the stray reference to the pprof R package

### DIFF
--- a/vignettes/jointprof.Rmd
+++ b/vignettes/jointprof.Rmd
@@ -225,7 +225,7 @@ pprof_file <- tempfile("jointprof", fileext = ".pb.gz")
 profile::write_pprof(profile_data, pprof_file)
 ```
 
-We then use `pprof` to visualize the call *graph*. The only exported function in the *pprof* package, [`get_pprof_pkg_path()`](https://r-prof.github.io/r-pprof/reference/get_pprof_pkg_path.html), tells us the path to the `pprof` executable.
+We then use `pprof` to visualize the call *graph*, using [`find_pprof()`](https://r-prof.github.io/jointprof/reference/find_pprof.html) to get the path to the `pprof` executable:
 
 ```{r minimal-graph}
 dir.create(knit_dir("jointprof_fig"), recursive = TRUE)


### PR DESCRIPTION
The vignette still contains a reference to the now-defunct **pprof** package, even though the code itself has been updated to use `find_pprof()`. This PR removes that stray reference.