### PR TITLE
Adds new error messages for more possible pprof installation issues

### DIFF
--- a/R/pprof.R
+++ b/R/pprof.R
@@ -46,9 +46,13 @@ find_pprof <- function() {
 
 get_gopath <- function() {
   if (is.null(.gopath_env$gopath)) {
+    if (nchar(Sys.which("go")) == 0) {
+      stop("The 'go' compiler tools must be installed. See `?find_pprof` for installation instructions.", call. = FALSE)
+    }
     gopath <- system2("go", c("env", "GOPATH"), stdout = TRUE)
-    stopifnot(file.exists(gopath))
-    stopifnot(file.info(gopath)$isdir)
+    if (!dir.exists(gopath)) {
+      stop("`GOPATH` does not yet exist. See `?find_pprof` for installation instructions.", call. = FALSE)
+    }
     .gopath_env$gopath <- gopath
   }
 


### PR DESCRIPTION
This adds two new error messages for gotchas I encountered when installing `pprof` myself, namely: (1) Go itself has not been installed; and (2) Go has been installed but `go get` has never been used.